### PR TITLE
Made the wifi reset message more clear

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -43,7 +43,7 @@ void setup()
   }
   if (WiFi.status() != WL_CONNECTED)
   {
-    Serial.println("Resetting");
+    Serial.println("Couldn't connect to WiFi, resetting");
     ESP.restart();
   }
   else


### PR DESCRIPTION
Hi! 

Just tried this today and got very confused by the boot loop. A message that explains why the device is rebooting will hopefully save someone else a few minutes