### PR TITLE
feat: Add ESP32 exception decoder to platformio.ini

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -16,6 +16,7 @@ lib_deps =
 	https://github.com/me-no-dev/ESPAsyncWebServer.git
 	bblanchon/ArduinoJson@^6.19.4
 monitor_speed = 115200
+monitor_filters = esp32_exception_decoder
 ; extra_scripts = upload.py
 ; upload_protocol = custom
 ; upload_url = http://192.168.178.50/update


### PR DESCRIPTION
Added the ESP32 exception decoder to `platformio.ini`. You will now see the stacktrace of a exception in the monitor tab.