### PR TITLE
Adding MQTT control and new weather features

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,15 +81,17 @@ Variables can be found inside `include/constants.h`.
 ```cpp
 #pragma once
 
-#define WIFI_HOSTNAME ""
-
-#ifdef ESP8266
 #define WIFI_SSID ""
 #define WIFI_PASSWORD ""
-#endif
+#define WIFI_HOSTNAME ""
 
 #define OTA_USERNAME ""
 #define OTA_PASSWORD ""
+
+#define LATITUDE ""
+#define LONGITUDE ""
+
+#define MQTTSERVERIP ""
 ```
 
 also set username and password inside `upload.py`, if you want to use OTA Updates.

--- a/include/PluginManager.h
+++ b/include/PluginManager.h
@@ -21,6 +21,7 @@ public:
 
     virtual void teardown();
     virtual void websocketHook(DynamicJsonDocument &request);
+    virtual void mqttHook(String topic, int message);
     virtual void setup() = 0;
     virtual void loop();
     virtual const char *getName() const = 0;

--- a/include/constants.h
+++ b/include/constants.h
@@ -29,17 +29,15 @@
 #ifdef ENABLE_SERVER
 // https://github.com/nayarsystems/posix_tz_db/blob/master/zones.json
 #define NTP_SERVER "de.pool.ntp.org"
-#define TZ_INFO "CET-1CEST,M3.5.0,M10.5.0/3"
+#define TZ_INFO "GMT0BST,M3.5.0/1,M10.5.0"
 #endif
 
 #define COLS 16
 #define ROWS 16
 
-// set your city or coords (https://github.com/chubin/wttr.in)
-#define WEATHER_LOCATION "Hamburg"
+// weather update frequency (minutes)
+#define WEATHER_UPDATE_FREQ 10
 
-// name of WiFi created by the device if no known WiFi is available
-#define WIFI_MANAGER_SSID "Ikea Display Setup WiFi"
 
 // use ALL of the following to use static IP config
 /*

--- a/include/mqtt.h
+++ b/include/mqtt.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <PubSubClient.h>
+#include "secrets.h"
+#include "websocket.h"
+#include "storage.h"
+#include "screen.h"
+
+#ifdef ESP8266
+#include <ESP8266WiFi.h>
+#endif
+
+extern WiFiClient espClient;
+extern PubSubClient MQTTclient;
+
+void mqttCallback(char* topic, byte* payload, unsigned int length);
+
+void mqttSetup();
+
+void mqttReconnect();

--- a/include/plugins/WeatherPlugin.h
+++ b/include/plugins/WeatherPlugin.h
@@ -10,31 +10,32 @@
 #endif
 #include <ArduinoJson.h>
 #include "PluginManager.h"
+#include "secrets.h"
 
 class WeatherPlugin : public Plugin
 {
 private:
-  unsigned long lastUpdate = 0;
+  long lastUpdate = 0;
+  bool tick = true;
+  bool weatherSettingsLoaded = false;
+  int weatherTime; //number of hours or days in the future
+  int weatherMode; //0 for current, 1 for hourly, 2 for daily
   HTTPClient http;
 
-  std::vector<int> thunderCodes = {200, 386, 389, 392, 395};
-  std::vector<int> cloudyCodes = {119, 122};
-  std::vector<int> partyCloudyCodes = {116};
-  std::vector<int> clearCodes = {113};
-  std::vector<int> fogCodes = {143, 248, 260};
-  std::vector<int> rainCodes = {
-      176, 293, 296, 299, 302,
-      305, 308, 311, 314, 353,
-      356, 359, 386, 389, 263,
-      266, 281, 284, 185};
-  std::vector<int> snowCodes = {
-      179, 227, 323, 326, 329,
-      332, 335, 338, 368, 371,
-      392, 395, 230, 350};
+  std::vector<int> thunderCodes = {95,96,99};
+  std::vector<int> cloudyCodes = {3};
+  std::vector<int> partyCloudyCodes = {1,2};
+  std::vector<int> clearCodes = {0};
+  std::vector<int> fogCodes = {45,48};
+  std::vector<int> rainCodes = {51,53,55,56,57,61,63,65,66,67,80,81,82};
+  std::vector<int> snowCodes = {71,73,75,77,85,86};
 
 public:
-  void update();
+  void mqttHook(String topic, int message);
+  void getUpdate();
+  void parseUpdate();
   void setup() override;
   void loop() override;
   const char *getName() const override;
+  void websocketHook(DynamicJsonDocument &request) override;
 };

--- a/src/PluginManager.cpp
+++ b/src/PluginManager.cpp
@@ -15,6 +15,7 @@ int Plugin::getId() const
 void Plugin::teardown() {}
 void Plugin::loop() {}
 void Plugin::websocketHook(DynamicJsonDocument &request) {}
+void Plugin::mqttHook(String topic, int message) {}
 
 PluginManager::PluginManager() : nextPluginId(1) {}
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,88 +1,50 @@
 #include <Arduino.h>
 #include <SPI.h>
 
-#ifdef ESP32
-#include <WiFiManager.h>
-#endif
-#ifdef ESP32
-#include <ESPmDNS.h>
-#endif
 #ifdef ESP8266
 #include <ESP8266WiFi.h>
+#endif
+#ifdef ESP32
+#include <WiFi.h>
+#include <IPAddress.h>
+#include <ESPmDNS.h>
 #endif
 
 #include "PluginManager.h"
 
-#include "plugins/BreakoutPlugin.h"
-#include "plugins/CirclePlugin.h"
 #include "plugins/DrawPlugin.h"
-#include "plugins/FireworkPlugin.h"
-#include "plugins/GameOfLifePlugin.h"
-#include "plugins/LinesPlugin.h"
-#include "plugins/RainPlugin.h"
+#include "plugins/BreakoutPlugin.h"
 #include "plugins/SnakePlugin.h"
+#include "plugins/GameOfLifePlugin.h"
 #include "plugins/StarsPlugin.h"
+#include "plugins/LinesPlugin.h"
+#include "plugins/CirclePlugin.h"
+#include "plugins/RainPlugin.h"
+#include "plugins/FireworkPlugin.h"
 
 #ifdef ENABLE_SERVER
-#include "plugins/AnimationPlugin.h"
 #include "plugins/BigClockPlugin.h"
 #include "plugins/ClockPlugin.h"
 #include "plugins/WeatherPlugin.h"
+#include "plugins/AnimationPlugin.h"
+#include "mqtt.h"
 #endif
 
-#include "asyncwebserver.h"
-#include "ota.h"
-#include "screen.h"
-#include "secrets.h"
 #include "websocket.h"
+#include "secrets.h"
+#include "ota.h"
+#include "webserver.h"
+#include "screen.h"
 
 unsigned long previousMillis = 0;
 unsigned long interval = 30000;
 
 PluginManager pluginManager;
 SYSTEM_STATUS currentStatus = NONE;
-#ifdef ESP32
-WiFiManager wifiManager;
-#endif
 
 unsigned long lastConnectionAttempt = 0;
 const unsigned long connectionInterval = 10000;
 
-#ifdef ESP32
-void connectToWiFi()
-{
-
-  // if a WiFi setup AP was started, reboot is required to clear routes
-  bool wifiWebServerStarted = false;
-  wifiManager.setWebServerCallback(
-      [&wifiWebServerStarted]()
-      { wifiWebServerStarted = true; });
-
-  wifiManager.setHostname(WIFI_HOSTNAME);
-  wifiManager.autoConnect(WIFI_MANAGER_SSID);
-
-  if (MDNS.begin(WIFI_HOSTNAME))
-  {
-    MDNS.addService("http", "tcp", 80);
-    MDNS.setInstanceName(WIFI_HOSTNAME);
-  }
-  else
-  {
-    Serial.println("Could not start mDNS!");
-  }
-
-  if (wifiWebServerStarted)
-  {
-    // Reboot required, otherwise wifiManager server interferes with our server
-    Serial.println("Done running WiFi Manager webserver - rebooting");
-    ESP.restart();
-  }
-
-  lastConnectionAttempt = millis();
-}
-#endif
-
-#ifdef ESP8266
 void connectToWiFi()
 {
   Serial.println("Connecting to Wi-Fi...");
@@ -90,8 +52,7 @@ void connectToWiFi()
   // Delete old config
   WiFi.disconnect(true);
 
-#if defined(IP_ADDRESS) && defined(GWY) && defined(SUBNET) && defined(DNS1) && \
-    defined(DNS2)
+#if defined(IP_ADDRESS) && defined(GWY) && defined(SUBNET) && defined(DNS1) && defined(DNS2)
   auto ip = IPAddress();
   ip.fromString(IP_ADDRESS);
 
@@ -127,6 +88,15 @@ void connectToWiFi()
   {
     Serial.print("Connected to WiFi network with IP Address: ");
     Serial.println(WiFi.localIP());
+
+#ifdef ESP32
+    if(MDNS.begin(WIFI_HOSTNAME)) {
+      MDNS.addService("http", "tcp", 80);
+      MDNS.setInstanceName(WIFI_HOSTNAME);
+    } else {
+      Serial.println("Could not start mDNS!");
+    }
+#endif
   }
   else
   {
@@ -134,8 +104,9 @@ void connectToWiFi()
   }
 
   lastConnectionAttempt = millis();
+
+  mqttSetup();
 }
-#endif
 
 void setup()
 {
@@ -184,6 +155,8 @@ void setup()
 void loop()
 {
   pluginManager.runActivePlugin();
+
+  MQTTclient.loop();
 
   if (WiFi.status() != WL_CONNECTED && millis() - lastConnectionAttempt > connectionInterval)
   {

--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -1,0 +1,63 @@
+#include <PubSubClient.h>
+#include "secrets.h"
+#include "PluginManager.h"
+#include "mqtt.h"
+#include "plugins/WeatherPlugin.h"
+
+#ifdef ESP8266
+#include <ESP8266WiFi.h>
+#endif
+#ifdef ESP32
+#endif
+
+WiFiClient espClient;
+PubSubClient MQTTclient(espClient);
+
+void mqttCallback(char* topic, byte* payload, unsigned int length) {
+  Serial.print("Message arrived [");
+  Serial.print(topic);
+  Serial.print("] ");
+  String message;
+  for (int i = 0; i < length; i++) {
+    //Serial.print((char)payload[i]);
+    message += String((char)payload[i]);
+  }
+  if (topic == "Obegraensad/mode")
+  {
+    pluginManager.setActivePluginById(message.toInt());
+  } else {
+    pluginManager.getActivePlugin()->mqttHook(topic, message.toInt());
+  }
+  Serial.print(message);
+  Serial.println();
+}
+
+void mqttSetup(){
+    MQTTclient.setServer(MQTTSERVERIP, 1883);
+    MQTTclient.setCallback(mqttCallback);
+    mqttReconnect();
+}
+
+void mqttReconnect() {
+  // Loop until we're reconnected
+  while (!MQTTclient.connected()) {
+    Serial.print("Attempting MQTT connection...");
+    // Create a random client ID
+    String clientId = "ESPClient-";
+    clientId += String(random(0xffff), HEX);
+    // Attempt to connect
+    if (MQTTclient.connect(clientId.c_str())) {
+      Serial.println("connected");
+      MQTTclient.subscribe("Obegraensad/mode");
+      MQTTclient.subscribe("Obegraensad/weatherMode");
+      MQTTclient.subscribe("Obegraensad/weatherTime");
+    } else {
+      Serial.print("failed, rc=");
+      Serial.print(MQTTclient.state());
+      Serial.println(" try again in 5 seconds");
+      // Wait 5 seconds before retrying
+      delay(5000);
+    }
+  }
+}
+

--- a/src/plugins/WeatherPlugin.cpp
+++ b/src/plugins/WeatherPlugin.cpp
@@ -1,12 +1,12 @@
 #include "plugins/WeatherPlugin.h"
 
-// https://github.com/chubin/wttr.in/blob/master/share/translations/en.txt
 #ifdef ESP8266
 WiFiClient wiFiClient;
 #endif
 
 void WeatherPlugin::setup()
 {
+    
     // loading screen
     Screen.clear();
     currentStatus = LOADING;
@@ -16,24 +16,58 @@ void WeatherPlugin::setup()
     Screen.setPixel(8, 7, 1);
     Screen.setPixel(10, 7, 1);
     Screen.setPixel(11, 7, 1);
-    this->lastUpdate = millis();
-    this->update();
+
+    this->lastUpdate = millis() - 1000 * 60 * WEATHER_UPDATE_FREQ + 15000;
     currentStatus = NONE;
 }
 
 void WeatherPlugin::loop()
 {
-    if (millis() >= this->lastUpdate + (1000 * 60 * 30))
+    if (millis() >= this->lastUpdate + (1000 * 60 * WEATHER_UPDATE_FREQ))
     {
-        this->update();
-        this->lastUpdate = millis();
-        Serial.println("updating weather");
+
+        if (!weatherSettingsLoaded)
+        {
+#ifdef ENABLE_STORAGE
+            storage.begin("weather", false);
+                if (this->weatherTime = storage.getInt("weatherTime",0))
+                {
+                    if (this->weatherMode = storage.getInt("weatherMode",0))
+                    {
+                        this->weatherSettingsLoaded = true;
+                    }
+                }
+                
+            storage.end();
+#else
+            this->weatherTime = 0;
+            this->weatherMode = 0;
+            this->weatherSettingsLoaded = true;
+#endif
+        }
+
+        if (tick) //downloads and parses updates separately on alternating loops to avoid triggering CPU watchdog
+        {
+            this->getUpdate();
+        } else {
+            this->parseUpdate();
+            this->lastUpdate = millis();
+        }
     };
 }
 
-void WeatherPlugin::update()
+void WeatherPlugin::getUpdate()
 {
-    String weatherApiString = "https://wttr.in/" + String(WEATHER_LOCATION) + "?format=j2&lang=en";
+    tryHtml:
+    String weatherApiString;
+    if (weatherMode == 0)
+    {
+      weatherApiString = String("https://api.open-meteo.com/v1/forecast?latitude=")+LATITUDE+String("&longitude=")+LONGITUDE+String("&current=temperature_2m,weather_code");
+    } else if (weatherMode == 1) {
+      weatherApiString = String("https://api.open-meteo.com/v1/forecast?latitude=")+LATITUDE+String("&longitude=")+LONGITUDE+String("&current=temperature_2m&minutely_15=temperature_2m,weather_code&timeformat=unixtime&forecast_days=2");
+    } else {
+        weatherApiString = String("https://api.open-meteo.com/v1/forecast?latitude=")+LATITUDE+String("&longitude=")+LONGITUDE+String("&current=temperature_2m&daily=temperature_2m_max,weather_code&timeformat=unixtime&forecast_days=7");
+    }
 #ifdef ESP32
     http.begin(weatherApiString);
 #endif
@@ -42,83 +76,154 @@ void WeatherPlugin::update()
 #endif
 
     int code = http.GET();
-
+    
     if (code == HTTP_CODE_OK)
     {
-        DynamicJsonDocument doc(2048);
-        deserializeJson(doc, http.getString());
-
-        int temperature = round(doc["current_condition"][0]["temp_C"].as<float>());
-        int weatherCode = doc["current_condition"][0]["weatherCode"].as<int>();
-        int weatherIcon = 0;
-        int iconY = 1;
-        int tempY = 10;
-
-        if (std::find(thunderCodes.begin(), thunderCodes.end(), weatherCode) != thunderCodes.end())
-        {
-            weatherIcon = 1;
-        }
-        else if (std::find(rainCodes.begin(), rainCodes.end(), weatherCode) != rainCodes.end())
-        {
-            weatherIcon = 4;
-        }
-        else if (std::find(snowCodes.begin(), snowCodes.end(), weatherCode) != snowCodes.end())
-        {
-            weatherIcon = 5;
-        }
-        else if (std::find(fogCodes.begin(), fogCodes.end(), weatherCode) != fogCodes.end())
-        {
-            weatherIcon = 6;
-            iconY = 2;
-        }
-        else if (std::find(clearCodes.begin(), clearCodes.end(), weatherCode) != clearCodes.end())
-        {
-            weatherIcon = 2;
-            iconY = 1;
-            tempY = 9;
-        }
-        else if (std::find(cloudyCodes.begin(), cloudyCodes.end(), weatherCode) != cloudyCodes.end())
-        {
-            weatherIcon = 0;
-            iconY = 2;
-            tempY = 9;
-        }
-        else if (std::find(partyCloudyCodes.begin(), partyCloudyCodes.end(), weatherCode) != partyCloudyCodes.end())
-        {
-            weatherIcon = 3;
-            iconY = 2;
-        }
-
-        Screen.clear();
-        Screen.drawWeather(0, iconY, weatherIcon, 100);
-
-        if (temperature >= 10)
-        {
-            Screen.drawCharacter(9, tempY, Screen.readBytes(degreeSymbol), 4, 50);
-            Screen.drawNumbers(1, tempY, {(temperature - temperature % 10) / 10, temperature % 10});
-        }
-        else if (temperature <= -10)
-        {
-            Screen.drawCharacter(0, tempY, Screen.readBytes(minusSymbol), 4);
-            Screen.drawCharacter(11, tempY, Screen.readBytes(degreeSymbol), 4, 50);
-            temperature *= -1;
-            Screen.drawNumbers(3, tempY, {(temperature - temperature % 10) / 10, temperature % 10});
-        }
-        else if (temperature >= 0)
-        {
-            Screen.drawCharacter(7, tempY, Screen.readBytes(degreeSymbol), 4, 50);
-            Screen.drawNumbers(4, tempY, {temperature});
-        }
-        else
-        {
-            Screen.drawCharacter(0, tempY, Screen.readBytes(minusSymbol), 4);
-            Screen.drawCharacter(9, tempY, Screen.readBytes(degreeSymbol), 4, 50);
-            Screen.drawNumbers(3, tempY, {-temperature});
-        }
+        tick = false;
     }
+}
+
+void WeatherPlugin::parseUpdate()
+{
+    DynamicJsonDocument doc(8096);
+    deserializeJson(doc, http.getString());
+
+    int currentTime = doc["current"]["time"].as<int>();
+    int forecastPoint;
+
+    if (weatherMode == 1)
+    {
+        //gets unix time forecast was provided, then does some math to look for closest 15-minute entry to the desired number of hours ahead
+        forecastPoint = round((currentTime-(86400*floor(currentTime/86400)))/(15*60))+(weatherTime*4);
+    } else if (weatherMode == 2) {
+        forecastPoint = weatherTime;
+    } else {
+        forecastPoint = 0;
+    }
+    
+    int temperature;
+    int weatherCode;
+
+    if (weatherMode == 0)
+    {
+        temperature = round(doc["current"]["temperature_2m"].as<float>());
+        weatherCode = doc["current"]["weather_code"].as<int>();
+    } else if (weatherMode == 1){
+        temperature = round(doc["minutely_15"]["temperature_2m"][forecastPoint].as<float>());
+        weatherCode = doc["minutely_15"]["weather_code"][forecastPoint].as<int>();
+    } else {
+        temperature = round(doc["daily"]["temperature_2m_max"][forecastPoint].as<float>());
+        weatherCode = doc["daily"]["weather_code"][forecastPoint].as<int>();
+    }
+    int weatherIcon = 0;
+    int iconY = 1;
+    int tempY = 10;
+
+    if (std::find(thunderCodes.begin(), thunderCodes.end(), weatherCode) != thunderCodes.end())
+    {
+        weatherIcon = 1;
+    }
+    else if (std::find(rainCodes.begin(), rainCodes.end(), weatherCode) != rainCodes.end())
+    {
+        weatherIcon = 4;
+    }
+    else if (std::find(snowCodes.begin(), snowCodes.end(), weatherCode) != snowCodes.end())
+    {
+        weatherIcon = 5;
+    }
+    else if (std::find(fogCodes.begin(), fogCodes.end(), weatherCode) != fogCodes.end())
+    {
+        weatherIcon = 6;
+        iconY = 2;
+    }
+    else if (std::find(clearCodes.begin(), clearCodes.end(), weatherCode) != clearCodes.end())
+    {
+        weatherIcon = 2;
+        iconY = 2;
+        tempY = 9;
+    }
+    else if (std::find(cloudyCodes.begin(), cloudyCodes.end(), weatherCode) != cloudyCodes.end())
+    {
+        weatherIcon = 0;
+        iconY = 2;
+        tempY = 9;
+    }
+    else if (std::find(partyCloudyCodes.begin(), partyCloudyCodes.end(), weatherCode) != partyCloudyCodes.end())
+    {
+        weatherIcon = 3;
+        iconY = 2;
+    }
+
+    Screen.clear();
+    Screen.drawWeather(0, iconY, weatherIcon);
+
+    if (temperature >= 10)
+    {
+        Screen.drawCharacter(9, tempY, Screen.readBytes(degreeSymbol), 4);
+        Screen.drawNumbers(1, tempY, {(temperature - temperature % 10) / 10, temperature % 10});
+    }
+    else if (temperature <= -10)
+    {
+        Screen.drawCharacter(0, tempY, Screen.readBytes(minusSymbol), 4);
+        Screen.drawCharacter(11, tempY, Screen.readBytes(degreeSymbol), 4);
+        Screen.drawNumbers(3, tempY, {(temperature - temperature % 10) / 10, temperature % 10});
+    }
+    else if (temperature >= 0)
+    {
+        Screen.drawCharacter(7, tempY, Screen.readBytes(degreeSymbol), 4);
+        Screen.drawNumbers(4, tempY, {temperature});
+    }
+    else
+    {
+        Screen.drawCharacter(0, tempY, Screen.readBytes(minusSymbol), 4);
+        Screen.drawCharacter(9, tempY, Screen.readBytes(degreeSymbol), 4);
+        Screen.drawNumbers(3, tempY, {temperature});
+    }
+    tick=true;
 }
 
 const char *WeatherPlugin::getName() const
 {
     return "Weather";
+}
+
+void WeatherPlugin::websocketHook(DynamicJsonDocument &request)
+{
+  const char *event = request["event"];
+
+  if (currentStatus == NONE)
+  {
+    if (!strcmp(event, "weatherTime"))
+    {
+      this->weatherTime = request["weatherTime"];
+      this->lastUpdate = millis() - 1000 * 60 * WEATHER_UPDATE_FREQ; //this tricks the loop into forcing an update without messing up CPU pinning
+#ifdef ENABLE_STORAGE
+      storage.begin("weather", false);
+        storage.putInt("weatherTime", this->weatherTime);
+      storage.end();
+#endif
+    } else if (!strcmp(event, "weatherMode")) {
+      this->weatherMode = request["weatherMode"];
+      this->lastUpdate = millis() - 1000 * 60 * WEATHER_UPDATE_FREQ;
+#ifdef ENABLE_STORAGE
+      storage.begin("weather", false);
+        storage.putInt("weatherMode", this->weatherMode);
+      storage.end();
+#endif
+    }
+  }
+}
+
+void WeatherPlugin::mqttHook(String topic, int message)
+{
+    if (topic == "Obegraensad/weatherMode")
+    {
+      this->weatherMode = message;
+      this->lastUpdate = millis() - 1000 * 60 * WEATHER_UPDATE_FREQ;
+    } else if (topic == "Obegraensad/weatherTime")
+    {
+      this->weatherTime = message;
+      this->lastUpdate = millis() - 1000 * 60 * WEATHER_UPDATE_FREQ;
+    }
+
 }

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -2,7 +2,7 @@
 #include <SPI.h>
 
 #define TIMER_INTERVAL_US 200
-#define GRAY_LEVELS 64 // must be a power of two
+#define GRAY_LEVELS 32 // must be a power of two
 
 using namespace std;
 
@@ -143,7 +143,7 @@ void Screen_::setup()
 #endif
 
 #ifdef ESP32
-  SPI.begin(PIN_CLOCK, 34, PIN_DATA, 25); // SCLK, MISO, MOSI, SS
+  SPI.begin(PIN_CLOCK, 20, PIN_DATA, 21); // SCLK, MISO, MOSI, SS
   SPI.beginTransaction(SPISettings(10000000, MSBFIRST, SPI_MODE0));
 
   hw_timer_t *Screen_timer = timerBegin(0, 80, true);

--- a/src/websocket.cpp
+++ b/src/websocket.cpp
@@ -19,7 +19,14 @@ void sendInfo()
   jsonDocument["event"] = "info";
   jsonDocument["rotation"] = Screen.currentRotation;
   jsonDocument["brightness"] = Screen.getCurrentBrightness();
-
+#ifdef ENABLE_STORAGE
+  storage.begin("weather", false);
+    int weatherTime = storage.getInt("weatherTime");
+    int weatherMode = storage.getInt("weatherMode");
+  storage.end();
+  jsonDocument["weatherMode"] = weatherMode;
+  jsonDocument["weatherTime"] = weatherTime;
+#endif
   JsonArray plugins = jsonDocument.createNestedArray("plugins");
 
   std::vector<Plugin *> &allPlugins = pluginManager.getAllPlugins();


### PR DESCRIPTION
This PR adds the ability to show forecast as well as current weather. It uses two new variables: weatherMode and weatherTime. weatherMode can be set to 0 (current), 1 (hourly forecast), or 2 (daily forecast); weatherTime sets the number of hours or days to look ahead. For example, if you want the forecasted weather one hour from now, set both weatherMode and weatherTime to 1.

I am not confident of my ability to edit the web GUI, so for now these settings can only be changed via websocket or the second contribution in this PR: MQTT control.

Three MQTT settings are currently available. Topics are "Obegraensad/mode" (changes the plugin), "Obegraensad/weatherMode", and "Obegraensad/weatherTime" (as above). Messages must be integers.