### PR TITLE
linear brightness control via web server

### DIFF
--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -160,10 +160,11 @@ export const App: Component = () => {
               <input
                 type="range"
                 min="0"
-                max="255"
+                max="65025"
                 value={store?.brightness()}
                 onInput={(e) => {
-                  const brightness = parseInt(e.currentTarget.value);
+                  //brightness by square root 65025; min is 0 and max is 255
+                  const brightness = Math.sqrt(parseInt(e.currentTarget.value));
                   store?.setBrightness(brightness);
                   sendBrightness(brightness);
                 }}


### PR DESCRIPTION
The brightness of LEDs is not a linear function. E.g. changing PWM from 1/255 to 2/255 will roughly experience a doubling of the amount of light for our eyes. Check https://en.wikipedia.org/wiki/Gamma_correction for more details.

I added square root function to correct brightness control input done via web server. This is a good enough correction to control low brightness.