### PR TITLE
Add DDP client plugin

### DIFF
--- a/include/plugins/DDPPlugin.h
+++ b/include/plugins/DDPPlugin.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "PluginManager.h"
+#include "AsyncUDP.h"
+
+class DDPPlugin : public Plugin
+{
+private:
+  AsyncUDP *udp;
+
+public:
+  void setup() override;
+  void teardown() override;
+  void loop() override;
+  const char *getName() const override;
+};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,6 +23,7 @@
 #include "plugins/SnakePlugin.h"
 #include "plugins/StarsPlugin.h"
 #include "plugins/PongClockPlugin.h"
+#include "plugins/DDPPlugin.h"
 
 #ifdef ENABLE_SERVER
 #include "plugins/AnimationPlugin.h"
@@ -199,6 +200,7 @@ void setup()
   pluginManager.addPlugin(new WeatherPlugin());
   pluginManager.addPlugin(new AnimationPlugin());
   pluginManager.addPlugin(new TickingClockPlugin());
+  pluginManager.addPlugin(new DDPPlugin());
 #endif
 
   pluginManager.init();

--- a/src/plugins/DDPPlugin.cpp
+++ b/src/plugins/DDPPlugin.cpp
@@ -1,0 +1,88 @@
+#include "plugins/DDPPlugin.h"
+
+void DDPPlugin::setup()
+{
+    udp = new AsyncUDP();
+    if (udp->listen(4048)) {
+        Serial.print("DDP server at IP: ");
+        Serial.print(WiFi.localIP());
+        Serial.println(" port: 4048");
+
+        // Network runs on Core 0, renderBuffer writes are thus concurrent with onScreenTimer's SPI writing.
+        udp->onPacket([](AsyncUDPPacket packet) {
+            // We could check the protocol but there is no real harm if not, display might look funny that's all.
+/*
+            // Check header flags
+            uint8_t *hdr = packet.data();
+            if (hdr[0] & 0xa0 != 0x40)
+            {
+                return; // expected protocol version 01
+            }
+            if (hdr[0] & 0x06 != 0)
+            {
+                return; // unexpected reply or query
+            }
+
+            // Check header data type
+            int data_type = hdr[2];
+            if (data_type != 0x00 && data_type != 0x08 && data_type != 0x20)
+            {
+                return; // unexpected data type
+            }
+*/
+            int count = (packet.length() - 10) / 3; // assumes 8 bit per channel RGB format
+            count = std::max(0, std::min(count, COLS * ROWS));
+            uint8_t *data = packet.data() + 10;
+
+            if (count == 1)
+            {
+                // virtual single pixel mode
+                uint8_t brightness = (data[0] + data[1] + data[2]) / 3; // average RGB
+                // uint8_t brightness = std::max(data[0], std::max(data[1], data[2])); // maximum brightness
+                for (unsigned i = 0; i < COLS * ROWS; i++)
+                {
+                    Screen.setPixelAtIndex(i, brightness > 4, brightness);
+                }
+            }
+
+            else if (count == ROWS)
+            {
+                // virtual row mode
+                for (unsigned i = 0; i < count; i++)
+                {
+                    uint8_t brightness = (data[i * 3] + data[i * 3 + 1] + data[i * 3 + 2]) / 3; // average RGB
+                    // uint8_t brightness = std::max(data[i * 3], std::max(data[i * 3 + 1], data[i * 3 + 2])); // maximum brightness
+                    for (unsigned k = 0; k < COLS; k++)
+                    {
+                        Screen.setPixelAtIndex(i * COLS + k, brightness > 4, brightness);
+                    }
+                }
+            }
+
+            else
+            {
+                for (unsigned i = 0; i < count; i++)
+                {
+                    uint8_t brightness = (data[i * 3] + data[i * 3 + 1] + data[i * 3 + 2]) / 3; // average RGB
+                    // uint8_t brightness = std::max(data[i * 3], std::max(data[i * 3 + 1], data[i * 3 + 2])); // maximum brightness
+                    Screen.setPixelAtIndex(i, brightness > 4, brightness);
+                }
+            }
+        });
+    }
+}
+
+void DDPPlugin::teardown()
+{
+    delete udp;
+}
+
+void DDPPlugin::loop()
+{
+    delay(1000);
+}
+
+const char *DDPPlugin::getName() const
+{
+    return "DDP";
+}

--- a/src/plugins/GameoflifePlugin.cpp
+++ b/src/plugins/GameoflifePlugin.cpp
@@ -8,10 +8,10 @@ uint8_t GameOfLifePlugin::countNeighbours(int row, int col)
   {
     for (j = col - 1; j <= col + 1; j++)
     {
-      count += this->buffer[i * 16 + j];
+      count += this->buffer[i * COLS + j];
     }
   }
-  count -= this->buffer[row * 16 + col];
+  count -= this->buffer[row * COLS + col];
   return count;
 };
 
@@ -22,13 +22,13 @@ uint8_t GameOfLifePlugin::updateCell(int row, int col)
   {
     return 0;
   }
-  else if (this->buffer[row * 16 + col] == 0 && total == 3)
+  else if (this->buffer[row * COLS + col] == 0 && total == 3)
   {
     return 1;
   }
   else
   {
-    return this->buffer[row * 16 + col];
+    return this->buffer[row * COLS + col];
   }
 };
 
@@ -51,7 +51,7 @@ void GameOfLifePlugin::next()
   {
     for (int j = 0; j < COLS; j++)
     {
-      this->buffer[i * 16 + j] = this->updateCell(i, j);
+      this->buffer[i * COLS + j] = this->updateCell(i, j);
     }
   }
 }
@@ -66,7 +66,7 @@ void GameOfLifePlugin::loop()
   {
     for (int j = 0; j < COLS; j++)
     {
-      Screen.setPixelAtIndex(i * 16 + j, this->buffer[i * 16 + j]);
+      Screen.setPixelAtIndex(i * COLS + j, this->buffer[i * COLS + j]);
     }
   }
   delay(150);

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -117,9 +117,9 @@ void Screen_::setPixelAtIndex(uint8_t index, uint8_t value, uint8_t brightness)
 
 void Screen_::setPixel(uint8_t x, uint8_t y, uint8_t value, uint8_t brightness)
 {
-  if (x >= 0 && y >= 0 && x < 16 && y < 16)
+  if (x >= 0 && y >= 0 && x < COLS && y < ROWS)
   {
-    this->renderBuffer_[y * 16 + x] = value <= 0 || brightness <= 0 ? 0 : (brightness > 255 ? 255 : brightness);
+    this->renderBuffer_[y * COLS + x] = value <= 0 || brightness <= 0 ? 0 : (brightness > 255 ? 255 : brightness);
   }
 }
 


### PR DESCRIPTION
I'm recently playing around with some LED controllers (e.g. [LedFx](https://github.com/LedFx/LedFx)).

How about adding a [DDP](http://www.3waylabs.com/ddp/) client plugin?

This is a very rough sketch to illustrate and as POC.

There are some discussion points:
- should we strictly check the DDP header?
- should we support other pixel formats than RGB (e.g. Grayscale)?
- is it better to use MAX(R, G, B) as brightness than AVG(R, G, B)?
- would (minimal) code to allow discovery be useful?