### PR TITLE
Remove time restrictions from clock display

### DIFF
--- a/src/plugins/TickingClockPlugin.cpp
+++ b/src/plugins/TickingClockPlugin.cpp
@@ -12,16 +12,6 @@ void TickingClockPlugin::loop()
 {
   if (getLocalTime(&timeinfo))
   {
-
-    if ((timeinfo.tm_hour * 60 + timeinfo.tm_min) < 6 * 60 + 30 ||
-        (timeinfo.tm_hour * 60 + timeinfo.tm_min) > 22 * 60 + 30) // only between 6:30 and 22:30
-    {
-      Screen.clear();
-      previousHH.clear();
-      previousMM.clear();
-      return;
-    }
-
     if (previousHour != timeinfo.tm_hour || previousMinutes != timeinfo.tm_min)
     {
 


### PR DESCRIPTION
While in general it is an appealing idea to switch off the device at night, this should not be handled by the plugin (at least not with fixed times).

Alternatives:
 - Create an automation using the Home Assistant Integration
 - Add time based schedules to frontend
 - Use a hardware timer switch.