### PR TITLE
Introduce configurable data via Web UI

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <Arduino.h>
+#include <string>
+#include "constants.h"
+
+#ifdef ENABLE_STORAGE
+#include <Preferences.h>
+#endif
+
+class Config
+{
+private:
+#ifdef ENABLE_STORAGE
+  Preferences preferences;
+  bool storageAvailable;
+#endif
+  
+  // Current values with safe defaults
+  String weatherLocation;
+  String ntpServer;
+  String tzInfo;
+  bool autoStartSchedule;
+  bool initialized;
+
+public:
+  Config();
+  
+  // Initialize configuration - always succeeds with defaults if storage fails
+  void begin();
+  
+  // Load from storage (safe - uses defaults on failure)
+  void load();
+  
+  // Save to storage (safe - fails silently)
+  void save();
+  
+  // Reset to hardcoded defaults
+  void setDefaults();
+  
+  // Getters (always return valid values)
+  String getWeatherLocation() const;
+  String getNtpServer() const;
+  String getTzInfo() const;
+  bool getAutoStartSchedule() const;
+  bool isInitialized() const { return initialized; }
+  
+  // Setters with validation
+  void setWeatherLocation(const String& location);
+  void setNtpServer(const String& server);
+  void setTzInfo(const String& tz);
+  void setAutoStartSchedule(bool autoStart);
+  
+  // Export to JSON
+  String toJson() const;
+  
+  // Import from JSON (validates input)
+  bool fromJson(const String& json);
+};
+
+extern Config config;

--- a/include/webhandler.h
+++ b/include/webhandler.h
@@ -17,3 +17,10 @@ void handleClearSchedule(AsyncWebServerRequest *request);
 void handleStopSchedule(AsyncWebServerRequest *request);
 void handleStartSchedule(AsyncWebServerRequest *request);
 void handleClearStorage(AsyncWebServerRequest *request);
+void handleGetConfig(AsyncWebServerRequest *request);
+void handleSetConfigBody(AsyncWebServerRequest *request,
+						 uint8_t *data,
+						 size_t len,
+						 size_t index,
+						 size_t total);
+void handleResetConfig(AsyncWebServerRequest *request);

--- a/src/asyncwebserver.cpp
+++ b/src/asyncwebserver.cpp
@@ -38,6 +38,24 @@ void initWebServer()
   server.on("/api/schedule/start", HTTP_GET, handleStartSchedule);
 
   server.on("/api/storage/clear", HTTP_GET, handleClearStorage);
+  
+    // Configuration endpoints
+    server.on("/api/config", HTTP_GET, handleGetConfig);
+    server.on(
+        "/api/config",
+        HTTP_POST,
+        [](AsyncWebServerRequest *request) {
+          // Response is sent after full body is received.
+        },
+        nullptr,
+        handleSetConfigBody);
+    server.on("/api/config/reset", HTTP_POST, handleResetConfig);
+  server.on("/config", HTTP_GET, [](AsyncWebServerRequest *request) {
+    request->send(200, "text/html", R"(
+<!DOCTYPE html>
+<html><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0"><title>LED Config</title><style>*{margin:0;padding:0;box-sizing:border-box}body{font-family:sans-serif;background:linear-gradient(135deg,#667eea 0%,#764ba2 100%);min-height:100vh;display:flex;justify-content:center;align-items:center;padding:20px}.container{background:#fff;border-radius:20px;box-shadow:0 20px 60px rgba(0,0,0,.3);max-width:600px;width:100%;padding:40px}h1{color:#333;margin-bottom:10px}#msg{padding:12px;margin:15px 0;border-radius:5px;display:none;word-wrap:break-word;font-size:13px;max-height:100px;overflow-y:auto}#msg.ok{background:#d4edda;color:#155724;border:1px solid #c3e6cb}#msg.err{background:#f8d7da;color:#721c24;border:1px solid #f5c6cb}label{display:block;margin-top:15px;font-weight:600}input{width:100%;padding:10px;margin-top:5px;border:2px solid #e0e0e0;border-radius:8px}input:focus{outline:0;border-color:#667eea}button{margin-top:20px;padding:12px 20px;border:none;border-radius:8px;font-weight:600;cursor:pointer;margin-right:10px}#save{background:#667eea;color:#fff}#reset{background:#ff4757;color:#fff}.hint{font-size:11px;color:#999;margin-top:3px}</style></head><body><div class="container"><h1>⚙️ LED Config</h1><div id="msg"></div><form id="form"><label>Weather Location<input id="wl" placeholder="Hamburg"><span class="hint">City name (e.g., Turin, Milan, Hamburg)</span></label><label>NTP Server<input id="ntp" placeholder="de.pool.ntp.org"><span class="hint">Time sync server</span></label><label>Timezone<input id="tz" placeholder="CET-1CEST,M3.5.0,M10.5.0/3"><span class="hint">POSIX timezone (CET-1CEST for Italy/Germany)</span></label><button type="submit" id="save">💾 Save</button><button type="button" id="reset">⚠️ Reset</button></form></div><script>const msg=document.getElementById('msg');function show(t,ok){msg.textContent=t;msg.className=ok?'ok':'err';msg.style.display='block';console.log((ok?'✅':'❌')+' '+t);setTimeout(()=>{msg.style.display='none'},6e3)}async function load(){console.log('[Config] Loading...');try{const r=await fetch('/api/config');console.log('[Config] Response:',r.status);if(!r.ok){show('Load failed ('+r.status+')',0);return}const d=await r.json();console.log('[Config] Data:',d);document.getElementById('wl').value=d.weatherLocation||'';document.getElementById('ntp').value=d.ntpServer||'';document.getElementById('tz').value=d.tzInfo||'';show('✅ Loaded',1)}catch(e){console.error('[Config] Load error:',e);show('Load error: '+e.message,0)}}document.getElementById('form').onsubmit=async e=>{e.preventDefault();const data={weatherLocation:document.getElementById('wl').value,ntpServer:document.getElementById('ntp').value,tzInfo:document.getElementById('tz').value,autoStartSchedule:false};console.log('[Config] Saving:',data);try{const r=await fetch('/api/config',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(data)});console.log('[Config] Response:',r.status);if(!r.ok){const err=await r.text();console.error('[Config] Error:',err);show('Save failed: '+err,0);return}show('✅ Saved!',1);setTimeout(load,500)}catch(e){console.error('[Config] Exception:',e);show('Save error: '+e.message,0)}};document.getElementById('reset').onclick=async()=>{if(!confirm('Reset all?'))return;console.log('[Config] Resetting');try{const r=await fetch('/api/config/reset',{method:'POST'});if(!r.ok){show('Reset failed',0);return}show('✅ Reset!',1);setTimeout(load,500)}catch(e){show('Reset error: '+e.message,0)}};load()</script></body></html>
+    )");
+  });
 
   server.begin();
 }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,0 +1,222 @@
+#include "config.h"
+#include <ArduinoJson.h>
+
+Config config;
+
+
+Config::Config()
+{
+  initialized = false;
+#ifdef ENABLE_STORAGE
+  storageAvailable = false;
+#endif
+  setDefaults();
+}
+
+
+void Config::begin()
+{
+  Serial.println("[Config] Initializing configuration system...");
+  
+  // Set safe defaults first
+  setDefaults();
+  
+#ifdef ENABLE_STORAGE
+  // Try to initialize storage
+  try {
+    if (preferences.begin("config", false)) {
+      storageAvailable = true;
+      Serial.println("[Config] Storage initialized successfully");
+      
+      // Try to load saved configuration
+      load();
+    } else {
+      Serial.println("[Config] Warning: Could not initialize storage, using defaults");
+      storageAvailable = false;
+    }
+  } catch (...) {
+    Serial.println("[Config] Error: Exception during storage init, using defaults");
+    storageAvailable = false;
+  }
+#else
+  Serial.println("[Config] Storage disabled, using defaults");
+#endif
+  
+  initialized = true;
+  
+  Serial.println("[Config] ============================================");
+  Serial.println("[Config] Current Configuration:");
+  Serial.print("[Config] Weather Location: ");
+  Serial.println(weatherLocation);
+  Serial.print("[Config] NTP Server: ");
+  Serial.println(ntpServer);
+  Serial.print("[Config] Timezone: ");
+  Serial.println(tzInfo);
+  Serial.print("[Config] Auto-Start Schedule: ");
+  Serial.println(autoStartSchedule ? "enabled" : "disabled");
+  Serial.println("[Config] ============================================");
+}
+
+void Config::setDefaults()
+{
+  // Use constants from constants.h as defaults
+  weatherLocation = String(WEATHER_LOCATION);
+  ntpServer = String(NTP_SERVER);
+  tzInfo = String(TZ_INFO);
+  autoStartSchedule = false;
+}
+
+void Config::load()
+{
+#ifdef ENABLE_STORAGE
+  if (!storageAvailable) {
+    Serial.println("[Config] Storage not available, keeping defaults");
+    return;
+  }
+  
+  try {
+    // Load with fallback to defaults
+    weatherLocation = preferences.getString("weatherLoc", String(WEATHER_LOCATION));
+    ntpServer = preferences.getString("ntpServer", String(NTP_SERVER));
+    tzInfo = preferences.getString("tzInfo", String(TZ_INFO));
+    autoStartSchedule = preferences.getBool("autoSchedule", false);
+    
+    Serial.println("[Config] Configuration loaded from storage");
+  } catch (...) {
+    Serial.println("[Config] Error loading config, using defaults");
+    setDefaults();
+  }
+#endif
+}
+
+void Config::save()
+{
+#ifdef ENABLE_STORAGE
+  if (!storageAvailable) {
+    Serial.println("[Config] Storage not available, cannot save");
+    return;
+  }
+  
+  try {
+    preferences.putString("weatherLoc", weatherLocation);
+    preferences.putString("ntpServer", ntpServer);
+    preferences.putString("tzInfo", tzInfo);
+    preferences.putBool("autoSchedule", autoStartSchedule);
+    
+    Serial.println("[Config] Configuration saved");
+  } catch (...) {
+    Serial.println("[Config] Error: Could not save configuration");
+  }
+#else
+  Serial.println("[Config] Storage disabled, cannot save");
+#endif
+}
+
+
+String Config::getWeatherLocation() const
+{
+  return weatherLocation.length() > 0 ? weatherLocation : String(WEATHER_LOCATION);
+}
+
+String Config::getNtpServer() const
+{
+  return ntpServer.length() > 0 ? ntpServer : String(NTP_SERVER);
+}
+
+String Config::getTzInfo() const
+{
+  return tzInfo.length() > 0 ? tzInfo : String(TZ_INFO);
+}
+
+bool Config::getAutoStartSchedule() const
+{
+  return autoStartSchedule;
+}
+
+void Config::setWeatherLocation(const String& location)
+{
+  if (location.length() > 0 && location.length() < 100) {
+    weatherLocation = location;
+  }
+}
+
+
+void Config::setNtpServer(const String& server)
+{
+  if (server.length() > 0 && server.length() < 100) {
+    ntpServer = server;
+  }
+}
+
+void Config::setTzInfo(const String& tz)
+{
+  if (tz.length() > 0 && tz.length() < 100) {
+    tzInfo = tz;
+  }
+}
+
+void Config::setAutoStartSchedule(bool autoStart)
+{
+  autoStartSchedule = autoStart;
+}
+
+
+String Config::toJson() const
+{
+  JsonDocument doc;
+  doc["weatherLocation"] = weatherLocation;
+  doc["ntpServer"] = ntpServer;
+  doc["tzInfo"] = tzInfo;
+  doc["autoStartSchedule"] = autoStartSchedule;
+  
+  String output;
+  serializeJson(doc, output);
+  return output;
+}
+
+
+bool Config::fromJson(const String& json)
+{
+  if (json.length() == 0) {
+    Serial.println("[Config] Empty JSON");
+    return false;
+  }
+  
+  JsonDocument doc;
+  DeserializationError error = deserializeJson(doc, json);
+  
+  if (error) {
+    Serial.print("[Config] JSON parse error: ");
+    Serial.println(error.c_str());
+    return false;
+  }
+  
+  // Validate and set each field
+  if (doc["weatherLocation"].is<String>()) {
+    String loc = doc["weatherLocation"].as<String>();
+    if (loc.length() > 0 && loc.length() < 100) {
+      weatherLocation = loc;
+    }
+  }
+  
+  if (doc["ntpServer"].is<String>()) {
+    String ntp = doc["ntpServer"].as<String>();
+    if (ntp.length() > 0 && ntp.length() < 100) {
+      ntpServer = ntp;
+    }
+  }
+  
+  if (doc["tzInfo"].is<String>()) {
+    String tz = doc["tzInfo"].as<String>();
+    if (tz.length() > 0 && tz.length() < 100) {
+      tzInfo = tz;
+    }
+  }
+  
+  if (doc["autoStartSchedule"].is<bool>()) {
+    autoStartSchedule = doc["autoStartSchedule"].as<bool>();
+  }
+  
+  return true;
+}
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,6 +17,7 @@
 #endif
 
 #include "PluginManager.h"
+#include "config.h"
 #include "scheduler.h"
 
 #include "plugins/ArtNet.h"
@@ -153,12 +154,15 @@ void baseSetup()
   Screen.setup();
 #endif
 
+  // Initialize configuration system (always safe)
+  config.begin();
+
 // server
 #ifdef ENABLE_SERVER
   connectToWiFi();
 
-  // set time server
-  configTzTime(TZ_INFO, NTP_SERVER);
+  // set time server using config values
+  configTzTime(config.getTzInfo().c_str(), config.getNtpServer().c_str());
 
   initOTA(server);
   initWebsocketServer(server);

--- a/src/plugins/WeatherPlugin.cpp
+++ b/src/plugins/WeatherPlugin.cpp
@@ -1,4 +1,5 @@
 #include "plugins/WeatherPlugin.h"
+#include "config.h"
 
 // https://github.com/chubin/wttr.in/blob/master/share/translations/en.txt
 #ifdef ESP32
@@ -64,8 +65,12 @@ void WeatherPlugin::update()
     return;
   }
 
-  String weatherApiString = "https://wttr.in/" + String(WEATHER_LOCATION) + "?format=j2&lang=en";
-  Serial.print("Requesting weather from: ");
+  String weatherLocation = config.getWeatherLocation();
+  Serial.print("[WeatherPlugin] Fetching weather for configured city: ");
+  Serial.println(weatherLocation);
+  
+  String weatherApiString = "https://wttr.in/" + weatherLocation + "?format=j2&lang=en";
+  Serial.print("[WeatherPlugin] API request: ");
   Serial.println(weatherApiString);
 
 #ifdef ESP32

--- a/src/webhandler.cpp
+++ b/src/webhandler.cpp
@@ -1,4 +1,5 @@
 #include "webhandler.h"
+#include "config.h"
 #include "messages.h"
 #include "scheduler.h"
 #include "websocket.h"
@@ -230,4 +231,125 @@ void handleClearStorage(AsyncWebServerRequest *request)
 
   sendJsonSuccess(request, "Storage cleared");
 #endif
+}
+
+void handleGetConfig(AsyncWebServerRequest *request)
+{
+  Serial.println("[WebHandler] GET /api/config");
+  try {
+    String json = config.toJson();
+    Serial.println("[WebHandler] ============================================");
+    Serial.println("[WebHandler] Current Configuration:");
+    Serial.print("[WebHandler] Weather Location: ");
+    Serial.println(config.getWeatherLocation());
+    Serial.print("[WebHandler] NTP Server: ");
+    Serial.println(config.getNtpServer());
+    Serial.print("[WebHandler] Timezone: ");
+    Serial.println(config.getTzInfo());
+    Serial.print("[WebHandler] Auto-Start Schedule: ");
+    Serial.println(config.getAutoStartSchedule() ? "enabled" : "disabled");
+    Serial.println("[WebHandler] ============================================");
+    request->send(200, "application/json", json);
+  } catch (...) {
+    Serial.println("[WebHandler] ERROR: Exception in handleGetConfig");
+    sendJsonError(request, 500, "Error reading configuration");
+  }
+}
+
+void handleSetConfigBody(AsyncWebServerRequest *request,
+                         uint8_t *data,
+                         size_t len,
+                         size_t index,
+                         size_t total)
+{
+  if (index == 0)
+  {
+    request->_tempObject = new String();
+  }
+
+  String *body = static_cast<String *>(request->_tempObject);
+  if (!body)
+  {
+    sendJsonError(request, 500, "Internal buffer error");
+    return;
+  }
+
+  if (index == 0)
+  {
+    body->reserve(total);
+  }
+
+  body->concat(reinterpret_cast<char *>(data), len);
+
+  if (index + len != total)
+  {
+    return;
+  }
+
+  Serial.println("[WebHandler] POST /api/config (body)");
+  Serial.print("[WebHandler] Received JSON: ");
+  Serial.println(*body);
+
+  try
+  {
+    if (body->length() == 0)
+    {
+      Serial.println("[WebHandler] ERROR: No JSON body");
+      sendJsonError(request, 400, "No JSON body provided");
+    }
+    else if (config.fromJson(*body))
+    {
+      Serial.println("[WebHandler] JSON parsed successfully");
+      config.save();
+      Serial.println("[WebHandler] ============================================");
+      Serial.println("[WebHandler] Configuration Updated:");
+      Serial.print("[WebHandler] Weather Location: ");
+      Serial.println(config.getWeatherLocation());
+      Serial.print("[WebHandler] NTP Server: ");
+      Serial.println(config.getNtpServer());
+      Serial.print("[WebHandler] Timezone: ");
+      Serial.println(config.getTzInfo());
+      Serial.print("[WebHandler] Auto-Start Schedule: ");
+      Serial.println(config.getAutoStartSchedule() ? "enabled" : "disabled");
+      Serial.println("[WebHandler] ============================================");
+      sendJsonSuccess(request, "Configuration saved successfully");
+    }
+    else
+    {
+      Serial.println("[WebHandler] ERROR: Invalid JSON format");
+      sendJsonError(request, 400, "Invalid JSON format");
+    }
+  }
+  catch (...)
+  {
+    Serial.println("[WebHandler] ERROR: Exception in handleSetConfigBody");
+    sendJsonError(request, 500, "Error saving configuration");
+  }
+
+  delete body;
+  request->_tempObject = nullptr;
+}
+
+void handleResetConfig(AsyncWebServerRequest *request)
+{
+  Serial.println("[WebHandler] POST /api/config/reset");
+  try {
+    config.setDefaults();
+    config.save();
+    Serial.println("[WebHandler] ============================================");
+    Serial.println("[WebHandler] Configuration Reset to Defaults:");
+    Serial.print("[WebHandler] Weather Location: ");
+    Serial.println(config.getWeatherLocation());
+    Serial.print("[WebHandler] NTP Server: ");
+    Serial.println(config.getNtpServer());
+    Serial.print("[WebHandler] Timezone: ");
+    Serial.println(config.getTzInfo());
+    Serial.print("[WebHandler] Auto-Start Schedule: ");
+    Serial.println(config.getAutoStartSchedule() ? "enabled" : "disabled");
+    Serial.println("[WebHandler] ============================================");
+    sendJsonSuccess(request, "Configuration reset to defaults");
+  } catch (...) {
+    Serial.println("[WebHandler] ERROR: Exception in handleResetConfig");
+    sendJsonError(request, 500, "Error resetting configuration");
+  }
 }


### PR DESCRIPTION
These changes are also needed to use my HACS custom integration to ensure all the features are supported from this version
https://github.com/lucaam/ikea-obegransad-led/releases/tag/v0.5.1

Preview of the Web UI:
<img width="648" height="598" alt="image" src="https://github.com/user-attachments/assets/5700296d-fedf-4ac7-aba6-31692eccbe1f" />


- Add a Config system with defaults, validation, and storage-backed persistence.
- Expose /api/config GET/POST plus reset endpoint.
- Serve a lightweight /config HTML page for editing weather, NTP, and timezone.
- Wire configuration into time sync and weather plugin behavior.