### PR TITLE
Minimal fix for clock not showing (no NTP)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -174,7 +174,11 @@ void baseSetup()
   connectToWiFi();
 
   // set time server using config values
-  configTzTime(config.getTzInfo().c_str(), config.getNtpServer().c_str());
+  // NOTE: lwIP SNTP stores the server-name pointer without copying it, so the
+  // String must outlive this call. Keep them static so their buffers persist.
+  static String tzInfo = config.getTzInfo();
+  static String ntpServer = config.getNtpServer();
+  configTzTime(tzInfo.c_str(), ntpServer.c_str());
 
   initOTA(server);
   initWebsocketServer(server);


### PR DESCRIPTION
See discussion in #231.

This the (most) minimal fix for the current NTP issue causing the clocks to not show at all.
@NemoN originally fixed this, but his fork includes a ton of other changes as well.