### PR TITLE
Fix global dimming logic in some plugins

### DIFF
--- a/src/plugins/TickingClockPlugin.cpp
+++ b/src/plugins/TickingClockPlugin.cpp
@@ -25,22 +25,22 @@ void TickingClockPlugin::loop()
                              0,
                              Screen.readBytes(fonts[1].data[hh[0]]),
                              8,
-                             Screen.getCurrentBrightness());
+                             MAX_BRIGHTNESS);
         Screen.drawCharacter(9,
                              0,
                              Screen.readBytes(fonts[1].data[hh[1]]),
                              8,
-                             Screen.getCurrentBrightness());
+                             MAX_BRIGHTNESS);
         Screen.drawCharacter(2,
                              9,
                              Screen.readBytes(fonts[1].data[mm[0]]),
                              8,
-                             Screen.getCurrentBrightness());
+                             MAX_BRIGHTNESS);
         Screen.drawCharacter(9,
                              9,
                              Screen.readBytes(fonts[1].data[mm[1]]),
                              8,
-                             Screen.getCurrentBrightness());
+                             MAX_BRIGHTNESS);
       }
       else
       {
@@ -50,7 +50,7 @@ void TickingClockPlugin::loop()
                                0,
                                Screen.readBytes(fonts[1].data[hh[0]]),
                                8,
-                               Screen.getCurrentBrightness());
+                               MAX_BRIGHTNESS);
         }
         if (hh[1] != previousHH[1])
         {
@@ -58,7 +58,7 @@ void TickingClockPlugin::loop()
                                0,
                                Screen.readBytes(fonts[1].data[hh[1]]),
                                8,
-                               Screen.getCurrentBrightness());
+                               MAX_BRIGHTNESS);
         }
         if (mm[0] != previousMM[0])
         {
@@ -66,7 +66,7 @@ void TickingClockPlugin::loop()
                                9,
                                Screen.readBytes(fonts[1].data[mm[0]]),
                                8,
-                               Screen.getCurrentBrightness());
+                               MAX_BRIGHTNESS);
         }
         if (mm[1] != previousMM[1])
         {
@@ -74,7 +74,7 @@ void TickingClockPlugin::loop()
                                9,
                                Screen.readBytes(fonts[1].data[mm[1]]),
                                8,
-                               Screen.getCurrentBrightness());
+                               MAX_BRIGHTNESS);
         }
       }
 
@@ -89,9 +89,9 @@ void TickingClockPlugin::loop()
       Screen.clearRect(0, 7, 16, 2);
       // alternating second pixel
       if ((timeinfo.tm_sec * 32 / 60) % 2 == 0)
-        Screen.setPixel(timeinfo.tm_sec * 16 / 60, 7, 1, Screen.getCurrentBrightness());
+        Screen.setPixel(timeinfo.tm_sec * 16 / 60, 7, 1, MAX_BRIGHTNESS);
       else
-        Screen.setPixel(timeinfo.tm_sec * 16 / 60, 8, 1, Screen.getCurrentBrightness());
+        Screen.setPixel(timeinfo.tm_sec * 16 / 60, 8, 1, MAX_BRIGHTNESS);
 
       previousSecond = timeinfo.tm_sec;
     }

--- a/src/plugins/WeatherPlugin.cpp
+++ b/src/plugins/WeatherPlugin.cpp
@@ -199,32 +199,32 @@ void WeatherPlugin::teardown()
 void WeatherPlugin::drawWeather()
 {
   Screen.clear();
-  Screen.drawWeather(0, cachedIconY, cachedWeatherIcon, 100);
+  Screen.drawWeather(0, cachedIconY, cachedWeatherIcon, MAX_BRIGHTNESS);
 
   int temperature = cachedTemperature;
   int tempY = cachedTempY;
 
   if (temperature >= 10)
   {
-    Screen.drawCharacter(9, tempY, Screen.readBytes(degreeSymbol), 4, 50);
+    Screen.drawCharacter(9, tempY, Screen.readBytes(degreeSymbol), 4, MAX_BRIGHTNESS);
     Screen.drawNumbers(1, tempY, {(temperature - temperature % 10) / 10, temperature % 10});
   }
   else if (temperature <= -10)
   {
     Screen.drawCharacter(0, tempY, Screen.readBytes(minusSymbol), 4);
-    Screen.drawCharacter(11, tempY, Screen.readBytes(degreeSymbol), 4, 50);
+    Screen.drawCharacter(11, tempY, Screen.readBytes(degreeSymbol), 4, MAX_BRIGHTNESS);
     temperature *= -1;
     Screen.drawNumbers(3, tempY, {(temperature - temperature % 10) / 10, temperature % 10});
   }
   else if (temperature >= 0)
   {
-    Screen.drawCharacter(7, tempY, Screen.readBytes(degreeSymbol), 4, 50);
+    Screen.drawCharacter(7, tempY, Screen.readBytes(degreeSymbol), 4, MAX_BRIGHTNESS);
     Screen.drawNumbers(4, tempY, {temperature});
   }
   else
   {
     Screen.drawCharacter(0, tempY, Screen.readBytes(minusSymbol), 4);
-    Screen.drawCharacter(9, tempY, Screen.readBytes(degreeSymbol), 4, 50);
+    Screen.drawCharacter(9, tempY, Screen.readBytes(degreeSymbol), 4, MAX_BRIGHTNESS);
     Screen.drawNumbers(3, tempY, {-temperature});
   }
 }

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -276,7 +276,12 @@ IRAM_ATTR void Screen_::_render()
     // Normal rendering with PWM for grayscale
     for (int idx = 0; idx < ROWS * COLS; idx++)
     {
-      uint16_t scaledValue = ((uint16_t)buf[positions[idx]] * brightness_) / MAX_BRIGHTNESS;
+      uint16_t pixelValue = buf[positions[idx]];
+      uint16_t scaledValue = ((uint16_t)pixelValue * brightness_) / MAX_BRIGHTNESS;
+      if (brightness_ > 0 && pixelValue > 0 && scaledValue == 0)
+      {
+        scaledValue = 1;
+      }
       bits[idx >> 3] |= (scaledValue > counter ? 0x80 : 0) >> (idx & 7);
     }
     counter += ((MAX_BRIGHTNESS + 1) / GRAY_LEVELS);


### PR DESCRIPTION
Fix for #244 

#### Summary

- Fixed `TickingClockPlugin` so digit updates and the second marker use intrinsic pixel brightness instead of double-scaling the current global brightness.
- Fixed `WeatherPlugin` so the weather icon and degree symbol render at the same brightness as the digits, preventing the degree symbol from appearing dimmer.
- Added a renderer-level safeguard in `src/screen.cpp` so any nonzero pixel remains visible when global brightness is above zero, avoiding missing elements at very low brightness settings.
