### PR TITLE
fix: use flash-safe pins on ESP32-C3

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,16 +121,16 @@ Inside you'll find 4 identical plates with 64 LEDs each (in 4 fields). Focus on 
 
 Connect the pins as shown below. Remember to configure them in `include/constants.h` according to your board.
 
-|       LCD        | ESP32  | TTGO LoRa32 | NodeMCUv2 | Lolin D32 (Pro) | Xiao ESP32S3 |
-| :--------------: | :----: | :---------: | :-------: | :-------------: | :----------: |
-|       GND        |  GND   |     GND     |    GND    |       GND       |     GND      |
-|       VCC        |   5V   |     5V      |    VIN    |       USB       |     VUSB     |
-| EN (PIN_ENABLE)  | GPIO26 |    IO22     | GPIO16 D0 |     GPIO26      |  D4 (GPIO5)  |
-|  IN (PIN_DATA)   | GPIO27 |    IO23     | GPIO13 D7 |     GPIO27      |  D10 (MOSI)  |
-| CLK (PIN_CLOCK)  | GPIO14 |    IO02     | GPIO14 D5 |     GPIO14      |   D8 (SCK)   |
-| CLA (PIN_LATCH)  | GPIO12 |    IO15     | GPIO0 D3  |     GPIO12      |  D5 (GPIO6)  |
-|  BUTTON one end  | GPIO16 |    IO21     | GPIO2 D4  |     GPIO25      |  D3 (GPIO4)  |
-| BUTTON other end |  GND   |     GND     |    GND    |       GND       |     GND      |
+|       LCD        | ESP32  | ESP32-C3 | TTGO LoRa32 | NodeMCUv2 | Lolin D32 (Pro) | Xiao ESP32S3 |
+| :--------------: | :----: | :------: | :---------: | :-------: | :-------------: | :----------: |
+|       GND        |  GND   |   GND    |     GND     |    GND    |       GND       |     GND      |
+|       VCC        |   5V   |    5V    |     5V      |    VIN    |       USB       |     VUSB     |
+| EN (PIN_ENABLE)  | GPIO26 |  GPIO3   |    IO22     | GPIO16 D0 |     GPIO26      |  D4 (GPIO5)  |
+|  IN (PIN_DATA)   | GPIO27 |  GPIO4   |    IO23     | GPIO13 D7 |     GPIO27      |  D10 (MOSI)  |
+| CLK (PIN_CLOCK)  | GPIO14 |  GPIO5   |    IO02     | GPIO14 D5 |     GPIO14      |   D8 (SCK)   |
+| CLA (PIN_LATCH)  | GPIO12 |  GPIO6   |    IO15     | GPIO0 D3  |     GPIO12      |  D5 (GPIO6)  |
+|  BUTTON one end  | GPIO16 |  GPIO7   |    IO21     | GPIO2 D4  |     GPIO25      |  D3 (GPIO4)  |
+| BUTTON other end |  GND   |   GND    |     GND     |    GND    |       GND       |     GND      |
 
 <img src="https://user-images.githubusercontent.com/86414213/205999001-6213fc4f-be2f-4305-a17a-44fdc9349069.jpg" width="60%" />
 

--- a/include/constants.h
+++ b/include/constants.h
@@ -5,7 +5,16 @@
 // disable if you do not want to have online functionality
 #define ENABLE_SERVER
 
-#ifdef ESP32
+// ESP32-C3 routes its internal SPI flash to GPIO12-17 (HD/WP/CS0/CLK/MOSI/MISO)
+// and only exposes GPIO0-21, so the generic ESP32 pins below are unusable there.
+// GPIO2/8/9 are strapping pins, 18/19 the native USB, 20/21 UART0.
+#if defined(CONFIG_IDF_TARGET_ESP32C3)
+#define PIN_ENABLE 3
+#define PIN_DATA 4
+#define PIN_CLOCK 5
+#define PIN_LATCH 6
+#define PIN_BUTTON 7
+#elif defined(ESP32)
 #define PIN_ENABLE 26
 #define PIN_DATA 27
 #define PIN_CLOCK 14

--- a/include/constants.h
+++ b/include/constants.h
@@ -5,15 +5,26 @@
 // disable if you do not want to have online functionality
 #define ENABLE_SERVER
 
-// ESP32-C3 routes its internal SPI flash to GPIO12-17 (HD/WP/CS0/CLK/MOSI/MISO)
-// and only exposes GPIO0-21, so the generic ESP32 pins below are unusable there.
-// GPIO2/8/9 are strapping pins, 18/19 the native USB, 20/21 UART0.
+// The ESP32 variants keep their SPI flash on different pins, so the generic
+// assignment further down is not usable everywhere. On the C3 the flash sits
+// on GPIO12-17 (HD/WP/CS0/CLK/MOSI/MISO) and nothing above GPIO21 exists; on
+// the S3 it occupies GPIO26-37. Driving any of those pins cuts the CPU off
+// from the flash it executes from.
 #if defined(CONFIG_IDF_TARGET_ESP32C3)
+// Free pins on the C3: GPIO2/8/9 are strapping, 18/19 native USB, 20/21 UART0.
 #define PIN_ENABLE 3
 #define PIN_DATA 4
 #define PIN_CLOCK 5
 #define PIN_LATCH 6
 #define PIN_BUTTON 7
+#elif defined(CONFIG_IDF_TARGET_ESP32S3)
+// Matches the Xiao ESP32S3 column of the wiring table in the README:
+// D4=GPIO5, D10/MOSI=GPIO9, D8/SCK=GPIO7, D5=GPIO6, D3=GPIO4.
+#define PIN_ENABLE 5
+#define PIN_DATA 9
+#define PIN_CLOCK 7
+#define PIN_LATCH 6
+#define PIN_BUTTON 4
 #elif defined(ESP32)
 #define PIN_ENABLE 26
 #define PIN_DATA 27


### PR DESCRIPTION
On the ESP32-C3 the firmware never boots. It resets in a loop with

    rst:0x8 (TG1WDT_SYS_RST),boot:0xf (SPI_FAST_FLASH_BOOT)

and prints nothing at all, which makes it look like a bad flash.

The cause is the pin block guarded by `#ifdef ESP32`. That guard matches
every ESP32 variant, but the numbers are those of a classic WROOM. The
C3 carries its in-package SPI flash on GPIO12-17 and only exposes
GPIO0-21, so three of the five pins land on the flash bus and two do not
exist at all:

| define | pin | on the C3 |
|---|---|---|
| `PIN_LATCH` | 12 | flash HD |
| `PIN_CLOCK` | 14 | flash **CS0** |
| `PIN_BUTTON` | 16 | flash MOSI |
| `PIN_DATA` | 27 | does not exist |
| `PIN_ENABLE` | 26 | does not exist |

The first `pinMode()` on GPIO14 detaches the flash chip select, the CPU
can no longer fetch code, and the watchdog resets it. The global
`BfButton` instance touches GPIO16 during static initialisation, which
is why the loop starts before `setup()` and no output ever appears.

This adds a separate assignment for the C3, avoiding the flash pins,
the strapping pins GPIO2/8/9, the native USB on GPIO18/19 and UART0 on
GPIO20/21. Other variants are untouched.

Verified on an ESP32-C3-DevKitM-1: with this change and nothing else the
firmware boots, stops resetting, and WiFiManager brings up its portal.